### PR TITLE
Add support for macOS (Darwin) for Java and Rust

### DIFF
--- a/src/monitors4codegen/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
+++ b/src/monitors4codegen/multilspy/language_servers/eclipse_jdtls/eclipse_jdtls.py
@@ -153,6 +153,7 @@ class EclipseJDTLS(LanguageServer):
         assert platformId.value in [
             "linux-x64",
             "win-x64",
+            "darwin-arm64",
         ], "Only linux-x64 platform is supported for in multilspy at the moment"
 
         gradle_path = str(

--- a/src/monitors4codegen/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
+++ b/src/monitors4codegen/multilspy/language_servers/eclipse_jdtls/runtime_dependencies.json
@@ -11,7 +11,12 @@
         "darwin-arm64": {
             "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-arm64-1.23.0.vsix",
             "archiveType": "zip",
-            "relative_extraction_path": "vscode-java"
+            "relative_extraction_path": "vscode-java",
+            "jre_home_path": "extension/jre/17.0.8.1-macosx-aarch64",
+            "jre_path": "extension/jre/17.0.8.1-macosx-aarch64/bin/java",
+            "lombok_jar_path": "extension/lombok/lombok-1.18.30.jar",
+            "jdtls_launcher_jar_path": "extension/server/plugins/org.eclipse.equinox.launcher_1.6.500.v20230717-2134.jar",
+            "jdtls_readonly_config_path": "extension/server/config_mac_arm"
         },
         "darwin-x64": {
             "url": "https://github.com/redhat-developer/vscode-java/releases/download/v1.23.0/java@darwin-x64-1.23.0.vsix",

--- a/src/monitors4codegen/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
+++ b/src/monitors4codegen/multilspy/language_servers/rust_analyzer/runtime_dependencies.json
@@ -16,6 +16,14 @@
             "platformId": "win-x64",
             "archiveType": "zip",
             "binaryName": "rust-analyzer.exe"
+        },
+        {
+            "id": "RustAnalyzer",
+            "description": "RustAnalyzer for macOS (arm64)",
+            "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-10-09/rust-analyzer-aarch64-apple-darwin.gz",
+            "platformId": "darwin-arm64",
+            "archiveType": "gz",
+            "binaryName": "rust-analyzer"
         }
     ]
 }

--- a/src/monitors4codegen/multilspy/language_servers/rust_analyzer/rust_analyzer.py
+++ b/src/monitors4codegen/multilspy/language_servers/rust_analyzer/rust_analyzer.py
@@ -52,6 +52,7 @@ class RustAnalyzer(LanguageServer):
         assert platform_id.value in [
             "linux-x64",
             "win-x64",
+            "darwin-arm64"
         ], "Only linux-x64 platform is supported for in multilspy at the moment"
 
         runtime_dependencies = d["runtimeDependencies"]

--- a/src/monitors4codegen/multilspy/multilspy_utils.py
+++ b/src/monitors4codegen/multilspy/multilspy_utils.py
@@ -171,9 +171,9 @@ class PlatformId(str, Enum):
     WIN_x86 = "win-x86"
     WIN_x64 = "win-x64"
     WIN_arm64 = "win-arm64"
-    OSX = "osx"
-    OSX_x64 = "osx-x64"
-    OSX_arm64 = "osx-arm64"
+    OSX = "darwin"
+    OSX_x64 = "darwin-x64"
+    OSX_arm64 = "darwin-arm64"
     LINUX_x86 = "linux-x86"
     LINUX_x64 = "linux-x64"
     LINUX_arm64 = "linux-arm64"
@@ -202,8 +202,8 @@ class PlatformUtils:
         system = platform.system()
         machine = platform.machine()
         bitness = platform.architecture()[0]
-        system_map = {"Windows": "win", "Darwin": "osx", "Linux": "linux"}
-        machine_map = {"AMD64": "x64", "x86_64": "x64", "i386": "x86", "i686": "x86", "aarch64": "arm64"}
+        system_map = {"Windows": "win", "Darwin": "darwin", "Linux": "linux"}
+        machine_map = {"AMD64": "x64", "x86_64": "x64", "i386": "x86", "i686": "x86", "aarch64": "arm64", "arm64": "arm64"}
         if system in system_map and machine in machine_map:
             platform_id = system_map[system] + "-" + machine_map[machine]
             if system == "Linux" and bitness == "64bit":


### PR DESCRIPTION
This fixes #17 , i.e. add support Java and Rust LSPs on macOS.